### PR TITLE
Fix hero backgrounds to show images by default

### DIFF
--- a/style.css
+++ b/style.css
@@ -279,21 +279,6 @@ body:not(.home) h1, body:not(.home) h2, body:not(.home) h3{ color: var(--sa-gree
 .image-strip .strip img{width:100%;height:220px;object-fit:cover;border-radius:16px}
 
 /* === FINAL, PAGE-SPECIFIC HERO COLOURS === */
-body.home .hero, body.home .page-hero{
-  background: none !important; background-color: var(--sa-blue) !important;
-}
-body.about .hero, body.about .page-hero, body.about .page-hero.warm{
-  background: none !important; background-color: var(--sa-green) !important;
-}
-body.programs .hero, body.programs .page-hero, body.programs .page-hero.cool{
-  background: none !important; background-color: var(--sa-red) !important;
-}
-body.contact .hero, body.contact .page-hero, body.contact .page-hero.stripes{
-  background: none !important; background-color: var(--sa-gold) !important;
-}
-body.blog .hero, body.blog .page-hero, body.blog .page-hero.gradient{
-  background: none !important; background-color: var(--sa-green) !important;
-}
 .hero::before, .page-hero::before{ content: none !important; display: none !important; }
 
 /* === HOME slider background photos === */


### PR DESCRIPTION
## Summary
- Remove page-specific CSS rules that replaced hero image backgrounds with solid colors
- Keep only pseudo-element reset so hero `image-set()` backgrounds display

## Testing
- `npx -p puppeteer@latest node -e "import('puppeteer').then(async p => {const browser=await p.launch();const page=await browser.newPage();await page.goto('file:///workspace/collossalcreativeacademy/index.html');const bg=await page.evaluate(()=>getComputedStyle(document.querySelector('.hero')).backgroundImage);console.log('index hero background:',bg);await browser.close();})" *(fails: 403 Forbidden to registry.npmjs.org)*
- `rg "image-set" -n style.css`

------
https://chatgpt.com/codex/tasks/task_e_68bea34c57b08323bace2bcf2d2b69ef