### PR TITLE
Restore solid hero colours

### DIFF
--- a/style.css
+++ b/style.css
@@ -261,6 +261,21 @@ body:not(.home) h1, body:not(.home) h2, body:not(.home) h3{ color: var(--sa-gree
 .image-strip .strip img{width:100%;height:220px;object-fit:cover;border-radius:16px}
 
 /* === FINAL, PAGE-SPECIFIC HERO COLOURS === */
+body.home .hero, body.home .page-hero{
+  background: none !important; background-color: var(--sa-blue) !important;
+}
+body.about .hero, body.about .page-hero, body.about .page-hero.warm{
+  background: none !important; background-color: var(--sa-green) !important;
+}
+body.programs .hero, body.programs .page-hero, body.programs .page-hero.cool{
+  background: none !important; background-color: var(--sa-red) !important;
+}
+body.contact .hero, body.contact .page-hero, body.contact .page-hero.stripes{
+  background: none !important; background-color: var(--sa-gold) !important;
+}
+body.blog .hero, body.blog .page-hero, body.blog .page-hero.gradient{
+  background: none !important; background-color: var(--sa-green) !important;
+}
 .hero::before, .page-hero::before{ content: none !important; display: none !important; }
 
 /* === HOME slider background photos === */


### PR DESCRIPTION
## Summary
- Reinstate page-specific solid background colours for all hero sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bea710bbe88323bac15165e117b7eb