### PR TITLE
Add dimensions and lazy loading to program image strip

### DIFF
--- a/programs.html
+++ b/programs.html
@@ -163,9 +163,9 @@
 
   <section class="image-strip">
     <div class="container strip">
-      <img src="make-up-1.png" alt="Creative">
-      <img src="yellow-dawing-1.png" alt="Creative">
-      <img src="make-up-2.png" alt="Creative">
+      <img src="make-up-1.png" alt="Creative" width="1024" height="1536" loading="lazy" decoding="async">
+      <img src="yellow-dawing-1.png" alt="Creative" width="1024" height="1536" loading="lazy" decoding="async">
+      <img src="make-up-2.png" alt="Creative" width="1024" height="1536" loading="lazy" decoding="async">
     </div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- add explicit width and height to image strip photos
- enable lazy loading and async decoding for program images

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beaa722ca48323acd2d4669a923631