### PR TITLE
Use lazy-loaded images for event cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,8 @@
       </div>
       <div class="event-grid">
         <article class="event-card">
-          <div class="event-media" style="--bg:url('creative-4.jpg')">
+          <div class="event-media">
+            <img src="creative-4.jpg" alt="Creative Fashion Photoshoot Day" loading="lazy" decoding="async">
             <!-- Price insert <span class="badge"></span>-->
           </div>
           <div class="event-body">
@@ -92,17 +93,19 @@
         </article>
 
         <article class="event-card">
-          <div class="event-media" style="--bg:url('creative-2.jpg')">
+          <div class="event-media">
+            <img src="creative-2.jpg" alt="Open Studio: Sketch &amp; Sip" loading="lazy" decoding="async">
             <!-- Price insert <span class="badge"></span>-->
           </div>
           <div class="event-body">
-            <h3>Open Studio: Sketch & Sip</h3>
+            <h3>Open Studio: Sketch &amp; Sip</h3>
             <p class="tiny muted">Thu evening • Materials included</p>
           </div>
         </article>
 
         <article class="event-card">
-          <div class="event-media" style="--bg:url('totebag1.jpg')">
+          <div class="event-media">
+            <img src="totebag1.jpg" alt="Sewing 101: Tote Workshop" loading="lazy" decoding="async">
             <!-- Price insert <span class="badge"></span>-->
           </div>
           <div class="event-body">

--- a/style.css
+++ b/style.css
@@ -250,9 +250,11 @@ body:not(.home) h1, body:not(.home) h2, body:not(.home) h3{ color: var(--sa-gree
 @media (max-width:1100px){ .event-grid{grid-template-columns:repeat(2,1fr)} }
 @media (max-width:680px){ .event-grid{grid-template-columns:1fr} }
 .event-card{background:var(--card); border-radius:var(--radius); overflow:hidden; box-shadow:var(--shadow)}
-.event-media{position:relative; aspect-ratio: 16/9; background: radial-gradient(80% 80% at 50% 30%, #ffffff66, transparent), #cbd5e1;
-  background: linear-gradient(0deg, rgba(0,0,0,.18), rgba(0,0,0,.18)), var(--bg) center/cover no-repeat;}
-.event-media .badge{position:absolute; left:.8rem; bottom:.8rem; background:#fff; color:#111; border-radius:999px; padding:.35rem .6rem; font-weight:700; box-shadow:var(--shadow)}
+.event-media{position:relative; aspect-ratio:16/9; overflow:hidden}
+.event-media img{position:absolute; inset:0; width:100%; height:100%; object-fit:cover; display:block}
+.event-media::after{content:""; position:absolute; inset:0; background:radial-gradient(80% 80% at 50% 30%, #ffffff66, transparent),
+  linear-gradient(0deg, rgba(0,0,0,.18), rgba(0,0,0,.18)); z-index:1; pointer-events:none}
+.event-media .badge{position:absolute; left:.8rem; bottom:.8rem; background:#fff; color:#111; border-radius:999px; padding:.35rem .6rem; font-weight:700; box-shadow:var(--shadow); z-index:2}
 .event-body{padding:.8rem 1rem}
 .event-body h3{margin:.2rem 0}
 


### PR DESCRIPTION
## Summary
- Replace event card background divs with `<img>` elements and add `loading="lazy"`/`decoding="async"`
- Style event media images and overlay gradient in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beaa81b820832398a7830cee6c37b9