### PR TITLE
Add intrinsic dimensions and lazy loading to image strip

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,9 +152,9 @@
 
   <section class="image-strip">
     <div class="container strip">
-      <img src="natural-skincare-1.png" alt="Creative">
-      <img src="silk-scissors.jpg" alt="Creative">
-      <img src="creative-1.jpg" alt="Creative">
+      <img src="natural-skincare-1.png" alt="Creative" width="1024" height="1536" loading="lazy" decoding="async">
+      <img src="silk-scissors.jpg" alt="Creative" width="498" height="674" loading="lazy" decoding="async">
+      <img src="creative-1.jpg" alt="Creative" width="1024" height="1536" loading="lazy" decoding="async">
     </div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- add intrinsic width/height attributes to image strip thumbnails
- enable lazy loading and async decoding for strip images to boost performance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beaa5f6d0883238e331634a26fe179