### PR TITLE
Lazy load header logo images

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,6 +19,7 @@
            srcset="logo-icon-only.png 1x, logo-icon-only@2x.png 2x"
            alt="Collossal Creative Academy logo"
            width="96" height="64"
+           loading="lazy"
            fetchpriority="high" decoding="async">
       <span class="brand-text"><span class="brand-name">Collossal</span> <span class="brand-sub">Creative Academy</span></span>
     </a>

--- a/blog.html
+++ b/blog.html
@@ -17,6 +17,7 @@
            srcset="logo-icon-only.png 1x, logo-icon-only@2x.png 2x"
            alt="Collossal Creative Academy logo"
            width="96" height="64"
+           loading="lazy"
            fetchpriority="high" decoding="async">
       <span class="brand-text"><span class="brand-name">Collossal</span> <span class="brand-sub">Creative Academy</span></span>
     </a>

--- a/contact.html
+++ b/contact.html
@@ -19,6 +19,7 @@
            srcset="logo-icon-only.png 1x, logo-icon-only@2x.png 2x"
            alt="Collossal Creative Academy logo"
            width="96" height="64"
+           loading="lazy"
            fetchpriority="high" decoding="async">
       <span class="brand-text"><span class="brand-name">Collossal</span> <span class="brand-sub">Creative Academy</span></span>
     </a>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <header class="site-header" role="banner" aria-label="Primary">
   <div class="container header-inner">
     <a class="brand" href="index.html" aria-label="Home">
-      <img class="logo-img" src="logo-icon-only.png" srcset="logo-icon-only.png 1x, logo-icon-only@2x.png 2x" alt="Collossal Creative Academy logo" width="96" height="64" fetchpriority="high" decoding="async">
+      <img class="logo-img" src="logo-icon-only.png" srcset="logo-icon-only.png 1x, logo-icon-only@2x.png 2x" alt="Collossal Creative Academy logo" width="96" height="64" loading="lazy" fetchpriority="high" decoding="async">
       <span class="brand-text"><span class="brand-name">Collossal</span> <span class="brand-sub">Creative Academy</span></span>
     </a>
 

--- a/programs.html
+++ b/programs.html
@@ -56,7 +56,7 @@
 <header class="site-header" role="banner" aria-label="Primary">
   <div class="container header-inner">
     <a class="brand" href="index.html" aria-label="Home">
-      <img class="logo-img" src="logo-icon-only.png" srcset="logo-icon-only.png 1x, logo-icon-only@2x.png 2x" alt="Collossal Creative Academy logo" width="96" height="64" fetchpriority="high" decoding="async">
+      <img class="logo-img" src="logo-icon-only.png" srcset="logo-icon-only.png 1x, logo-icon-only@2x.png 2x" alt="Collossal Creative Academy logo" width="96" height="64" loading="lazy" fetchpriority="high" decoding="async">
       <span class="brand-text"><span class="brand-name">Collossal</span> <span class="brand-sub">Creative Academy</span></span>
     </a>
 


### PR DESCRIPTION
## Summary
- defer header logo image loading across site pages by adding `loading="lazy"`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beaccbc700832387a4f307ba5a8234