### PR TITLE
Lazy-load slider backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,25 +43,25 @@
       </div>
       <div class="hero-slider" role="region" aria-label="Showcase slider">
         <div class="slides">
-          <div class="slide" aria-label="Sketching & Drawing">
+          <div class="slide" aria-label="Sketching & Drawing" data-bg="sketch-hand.jpg">
             <div class="slide-card">
               <h3>Sketching &amp; Drawing</h3>
               <p>From line to life — master fundamentals that power every creative path.</p>
             </div>
           </div>
-          <div class="slide" aria-label="Painting on Fabric & Canvas">
+          <div class="slide" aria-label="Painting on Fabric & Canvas" data-bg="block-print.jpg">
             <div class="slide-card">
               <h3>Fabric &amp; Canvas Painting</h3>
               <p>Bring color to textiles and canvas — craft pieces that stand out and sell.</p>
             </div>
           </div>
-          <div class="slide" aria-label="Sewing & Product Design">
+          <div class="slide" aria-label="Sewing & Product Design" data-bg="sewing-machine.jpg">
             <div class="slide-card">
               <h3>Sewing &amp; Product Design</h3>
               <p>Cut, stitch, and finish quality items — from custom totes to wearable art.</p>
             </div>
           </div>
-          <div class="slide" aria-label="Market-Ready Marketing">
+          <div class="slide" aria-label="Market-Ready Marketing" data-bg="sketch-to-runway.jpg">
             <div class="slide-card">
               <h3>Market-Ready Marketing</h3>
               <p>Turn creations into income with practical tools to launch and sell online.</p>

--- a/scripts.js
+++ b/scripts.js
@@ -37,6 +37,28 @@
 })();
 
 
+/* Lazy-load slide backgrounds */
+(function(){
+  const slides = document.querySelectorAll('.hero-slider .slide[data-bg]');
+  if(!slides.length) return;
+  const gradient = "linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28))";
+  const io = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if(entry.isIntersecting){
+        const el = entry.target;
+        const bg = el.dataset.bg;
+        el.style.backgroundImage = `${gradient}, url('${bg}')`;
+        el.style.backgroundPosition = 'center';
+        el.style.backgroundSize = 'cover';
+        el.style.backgroundRepeat = 'no-repeat';
+        io.unobserve(el);
+      }
+    });
+  });
+  slides.forEach(s => io.observe(s));
+})();
+
+
 /* Rotating background for Sewing & Product Design slide */
 (function(){
   const el = document.querySelector('.slide.sewing-rotator');

--- a/style.css
+++ b/style.css
@@ -283,20 +283,16 @@ body.blog .hero, body.blog .page-hero, body.blog .page-hero.gradient{
 /* === HOME slider background photos === */
 .hero-slider .slides .slide{ background-blend-mode: normal; }
 .hero-slider .slides .slide:nth-child(1){
-  background: linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28)),
-              url('sketch-hand.jpg') center/cover no-repeat !important;
+  background: linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28)) !important;
 }
 .hero-slider .slides .slide:nth-child(2){
-  background: linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28)),
-              url('block-print.jpg') center/cover no-repeat !important;
+  background: linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28)) !important;
 }
 .hero-slider .slides .slide:nth-child(3){
-  background: linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28)),
-              url('sewing-machine.jpg') center/cover no-repeat !important;
+  background: linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28)) !important;
 }
 .hero-slider .slides .slide:nth-child(4){
-  background: linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28)),
-              url('sketch-to-runway.jpg') center/cover no-repeat !important;
+  background: linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28)) !important;
 }
 
 /* === HOME tweaks === */


### PR DESCRIPTION
## Summary
- Move slider background image paths into `data-bg` attributes and strip URLs from the CSS nth-child rules
- Use IntersectionObserver to apply background images on demand when slides enter the viewport

## Testing
- `npm test` *(fails: missing package.json)*
- `node --check scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_68beacd94fac8323ad6cf40ef4147359