### PR TITLE
Use img elements for hero slider backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,25 +43,29 @@
       </div>
       <div class="hero-slider" role="region" aria-label="Showcase slider">
         <div class="slides">
-          <div class="slide" aria-label="Sketching & Drawing" data-bg="sketch-hand.jpg">
+          <div class="slide" aria-label="Sketching & Drawing">
+            <img class="slide-img" src="sketch-hand.jpg" alt="Sketching &amp; Drawing">
             <div class="slide-card">
               <h3>Sketching &amp; Drawing</h3>
               <p>From line to life — master fundamentals that power every creative path.</p>
             </div>
           </div>
-          <div class="slide" aria-label="Painting on Fabric & Canvas" data-bg="block-print.jpg">
+          <div class="slide" aria-label="Painting on Fabric & Canvas">
+            <img class="slide-img" src="block-print.jpg" alt="Fabric &amp; Canvas Painting">
             <div class="slide-card">
               <h3>Fabric &amp; Canvas Painting</h3>
               <p>Bring color to textiles and canvas — craft pieces that stand out and sell.</p>
             </div>
           </div>
-          <div class="slide" aria-label="Sewing & Product Design" data-bg="sewing-machine.jpg">
+          <div class="slide" aria-label="Sewing & Product Design">
+            <img class="slide-img" src="sewing-machine.jpg" alt="Sewing &amp; Product Design">
             <div class="slide-card">
               <h3>Sewing &amp; Product Design</h3>
               <p>Cut, stitch, and finish quality items — from custom totes to wearable art.</p>
             </div>
           </div>
-          <div class="slide" aria-label="Market-Ready Marketing" data-bg="sketch-to-runway.jpg">
+          <div class="slide" aria-label="Market-Ready Marketing">
+            <img class="slide-img" src="sketch-to-runway.jpg" alt="Market-Ready Marketing">
             <div class="slide-card">
               <h3>Market-Ready Marketing</h3>
               <p>Turn creations into income with practical tools to launch and sell online.</p>

--- a/scripts.js
+++ b/scripts.js
@@ -38,71 +38,71 @@
 
 
 /* Lazy-load slide backgrounds */
-(function(){
-  const slides = document.querySelectorAll('.hero-slider .slide[data-bg]');
-  if(!slides.length) return;
-  const gradient = "linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28))";
-  const io = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if(entry.isIntersecting){
-        const el = entry.target;
-        const bg = el.dataset.bg;
-        el.style.backgroundImage = `${gradient}, url('${bg}')`;
-        el.style.backgroundPosition = 'center';
-        el.style.backgroundSize = 'cover';
-        el.style.backgroundRepeat = 'no-repeat';
-        io.unobserve(el);
-      }
-    });
-  });
-  slides.forEach(s => io.observe(s));
-})();
+// (function(){
+//   const slides = document.querySelectorAll('.hero-slider .slide[data-bg]');
+//   if(!slides.length) return;
+//   const gradient = "linear-gradient(135deg, rgba(248,250,252,.28), rgba(238,242,255,.28))";
+//   const io = new IntersectionObserver(entries => {
+//     entries.forEach(entry => {
+//       if(entry.isIntersecting){
+//         const el = entry.target;
+//         const bg = el.dataset.bg;
+//         el.style.backgroundImage = `${gradient}, url('${bg}')`;
+//         el.style.backgroundPosition = 'center';
+//         el.style.backgroundSize = 'cover';
+//         el.style.backgroundRepeat = 'no-repeat';
+//         io.unobserve(el);
+//       }
+//     });
+//   });
+//   slides.forEach(s => io.observe(s));
+// })();
 
 
 /* Rotating background for Sewing & Product Design slide */
-(function(){
-  const el = document.querySelector('.slide.sewing-rotator');
-  if(!el) return;
-  const imgs = [
-    "sewing-offer-1.jpg",
-    "sewing-offer-2.jpg",
-    "sewing-offer-3.jpg"
-  ];
-  const cache = {};
-  let i = 0;
+// (function(){
+//   const el = document.querySelector('.slide.sewing-rotator');
+//   if(!el) return;
+//   const imgs = [
+//     "sewing-offer-1.jpg",
+//     "sewing-offer-2.jpg",
+//     "sewing-offer-3.jpg"
+//   ];
+//   const cache = {};
+//   let i = 0;
 
-  function setBg(idx){
-    el.style.background = `linear-gradient(0deg, rgba(0,0,0,.15), rgba(0,0,0,.15)), url(${imgs[idx]}) center/cover no-repeat`;
-  }
+//   function setBg(idx){
+//     el.style.background = `linear-gradient(0deg, rgba(0,0,0,.15), rgba(0,0,0,.15)), url(${imgs[idx]}) center/cover no-repeat`;
+//   }
 
-  function load(idx, cb){
-    if(cache[idx]) return cb();
-    const img = new Image();
-    img.src = imgs[idx];
-    img.onload = () => { cache[idx] = true; cb(); };
-  }
+//   function load(idx, cb){
+//     if(cache[idx]) return cb();
+//     const img = new Image();
+//     img.src = imgs[idx];
+//     img.onload = () => { cache[idx] = true; cb(); };
+//   }
 
-  function start(){
-    cache[i] = true;
-    setBg(i);
-    setInterval(()=>{
-      i = (i+1)%imgs.length;
-      load(i, ()=>setBg(i));
-    }, 3500);
-  }
+//   function start(){
+//     cache[i] = true;
+//     setBg(i);
+//     setInterval(()=>{
+//       i = (i+1)%imgs.length;
+//       load(i, ()=>setBg(i));
+//     }, 3500);
+//   }
 
-  if('IntersectionObserver' in window){
-    const obs = new IntersectionObserver((entries, observer)=>{
-      if(entries.some(e=>e.isIntersecting)){
-        observer.disconnect();
-        start();
-      }
-    });
-    obs.observe(el);
-  }else{
-    start();
-  }
-})();
+//   if('IntersectionObserver' in window){
+//     const obs = new IntersectionObserver((entries, observer)=>{
+//       if(entries.some(e=>e.isIntersecting)){
+//         observer.disconnect();
+//         start();
+//       }
+//     });
+//     obs.observe(el);
+//   }else{
+//     start();
+//   }
+// })();
 
 
 /* overlay slider controls */

--- a/style.css
+++ b/style.css
@@ -80,6 +80,14 @@ body{
   background-image: linear-gradient(135deg, #f8fafc, #eef2ff);
   border-radius:var(--radius);
 }
+.hero-slider .slide{position:relative}
+.hero-slider .slide-img{
+  position:absolute;
+  top:0;left:0;
+  width:100%;height:100%;
+  object-fit:cover;
+  z-index:-1;
+}
 .slide-card{width:90%; background:#fff; border-radius:16px; padding:1rem; box-shadow:var(--shadow); text-align:center}
 .slider-dots{display:flex; gap:.4rem; justify-content:center; margin-top:.7rem}
 .slider-dots button{width:8px;height:8px;border-radius:999px;border:0;background:#cbd5e1}


### PR DESCRIPTION
## Summary
- Replace hero slide `data-bg` attributes with inline `<img>` tags and meaningful alt text
- Add styling to position new slide images and keep card foreground intact
- Comment out unused background-loading JavaScript blocks

## Testing
- `npm install jsdom@latest --no-save` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_68bef9efd9b88323999c608b5b8c7380